### PR TITLE
SIK-2364: Update gundi-client-v2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ backoff==2.2
 aiofiles==23.2.1
 gundi-core==1.2.5
 gundi-client==1.0.1
-gundi-client-v2==2.1.1
+gundi-client-v2==2.1.2
 movebank-client==1.0.0
 opentelemetry-api==1.14.0
 opentelemetry-sdk==1.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ grpcio-status==1.57.0
     # via google-api-core
 gundi-client==1.0.1
     # via -r requirements.in
-gundi-client-v2==2.1.1
+gundi-client-v2==2.1.2
     # via -r requirements.in
 gundi-core==1.2.5
     # via


### PR DESCRIPTION
### What does this PR do?
- Update the gundi client v2 to the latest version after we removed `/api/` from the URL path
- This is covered by regression tests.

### Relevant link(s)
[SIK-2364](https://allenai.atlassian.net/browse/SIK-2364)

[SIK-2364]: https://allenai.atlassian.net/browse/SIK-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ