### PR TITLE
feat(ci): wire deploy_dev to ArgoCD image-bump workflow (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,18 +51,17 @@ jobs:
       tag: ${{ needs.vars.outputs.tag }}
 
   deploy_dev:
-    # Disabled: gundi-dev migrated to ArgoCD via DASOPS-1995.
-    # Image bumps for dev now go through a values commit in
-    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-dev.yaml.
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
-    if: false
+    # gundi-dev is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-dev.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
+    if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
-      environment: dev
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: movebank-dispatcher
+      environment: gundi-dev
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit  # pragma: allowlist secret
 
   deploy_stage:


### PR DESCRIPTION
## Summary

Re-enables the `deploy_dev` job — disabled by DASOPS-1995 during the ArgoCD cutover — pointing at the new reusable workflow `PADAS/gundi-workflows/deploy_argocd.yml@v8`. On push to `main`, the job now bumps `image.tag` in `PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-dev.yaml` and lets ArgoCD's `selfHeal` reconcile.

## Changes

- `.github/workflows/main.yml`: replace `deploy_dev`'s `if: false` + `deploy_k8s.yml@v2` call with `deploy_argocd.yml@v8`, passing `app-name: movebank-dispatcher`, `environment: gundi-dev`.

`deploy_stage` and `deploy_prod` are untouched.

## Prerequisites

1. `PADAS/gundi-workflows#9` merged + tag `v8` pushed.
2. `ARGOCD_APPS_SSH_KEY` secret provisioned on this repo.

## Verification

After merge, push a no-op commit to `main` and observe:
- `deploy_dev` job runs green.
- A new commit lands on `PADAS/serca-argocd-apps:main` bumping `gundi/movebank-dispatcher/values-gundi-dev.yaml`.
- `kubectl --context serca-tools get app movebank-dispatcher-gundi-dev -n argocd` flips `OutOfSync` → `Synced`.
- A new `movebank-dispatcher` pod rolls out on `gundi-dev`.

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995