### PR TITLE
feat(ci): flip deploy_stage to ArgoCD image-bump workflow (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,15 +65,17 @@ jobs:
     secrets: inherit  # pragma: allowlist secret
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    # gundi-stage is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-stage.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
-      environment: stage
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: movebank-dispatcher
+      environment: gundi-stage
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit  # pragma: allowlist secret
 
   deploy_prod:


### PR DESCRIPTION
## Summary

Stage counterpart of #13. Flips `deploy_stage` from `deploy_k8s.yml@v2` to `deploy_argocd.yml@v8`. On push to `release-*`, bumps `image.tag` in `PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-stage.yaml`.

## Changes

- `.github/workflows/main.yml` — `deploy_stage` block now calls `deploy_argocd.yml@v8` with `app-name: movebank-dispatcher`, `environment: gundi-stage`.

`deploy_prod` untouched (still on `deploy_k8s.yml@v2`) — prod cutover is a separate sub-task.

## Prerequisites

1. Wave 2a merged: `PADAS/serca-argocd-apps#187` + `PADAS/serca-argocd#196`.
2. `ARGOCD_APPS_SSH_KEY` already provisioned (dev rollout).

## Verification

After merge + release-* push: `deploy_stage` runs green → commit on `serca-argocd-apps` → ArgoCD syncs `movebank-dispatcher-gundi-stage` → pod rolls.

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995