### PR TITLE
feat(ci): flip deploy_prod to ArgoCD image-bump workflow (DASOPS-1995)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,13 +79,15 @@ jobs:
     secrets: inherit  # pragma: allowlist secret
 
   deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    # gundi-prod is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-prod.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
     with:
-      environment: prod
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
+      app-name: movebank-dispatcher
+      environment: gundi-prod
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Prod counterpart of #13 (dev) and #14 (stage). Flips `deploy_prod` from `deploy_k8s.yml@v2` to `deploy_argocd.yml@v8`. Completes the dev/stage/prod migration to the ArgoCD pattern.

## Changes

- `.github/workflows/main.yml` — `deploy_prod`: `app-name: movebank-dispatcher`, `environment: gundi-prod`, `needs: [vars, build, deploy_stage]` unchanged.

## Prerequisites

1. `PADAS/serca-argocd-apps#188` + `PADAS/serca-argocd#197` merged.
2. `ARGOCD_APPS_SSH_KEY` already provisioned.

## Verification

Next `release-*` push: `deploy_prod` runs green → commit on `serca-argocd-apps` → ArgoCD syncs `movebank-dispatcher-gundi-prod` → pod rolls (replicaCount 2).

---
**Jira**: https://allenai.atlassian.net/browse/DASOPS-1995