### PR TITLE
feat(DASOPS-2057): push to serca-artifact-registry and mirror Dockerfile base image (dev)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,14 @@ jobs:
     outputs:
       tag: ${{ steps.vars.outputs.tag }}
       repository: ${{ steps.vars.outputs.repository }}
+      serca_repository: ${{ steps.vars.outputs.serca_repository }}
     steps:
       - uses: actions/checkout@v4
       - id: vars
         run: |
           echo "tag=${{ github.head_ref || github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/movebank-dispatcher" >> $GITHUB_OUTPUT
+          echo "serca_repository=europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/movebank-dispatcher" >> $GITHUB_OUTPUT
 
   run_unit_tests:
       runs-on: ubuntu-latest
@@ -50,17 +52,25 @@ jobs:
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
 
+  build_serca:
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v9
+    needs: [run_unit_tests, vars]
+    with:
+      workload_identity_provider: "projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"  # pragma: allowlist secret
+      repository: ${{ needs.vars.outputs.serca_repository }}
+      tag: ${{ needs.vars.outputs.tag }}
+
   deploy_dev:
     # gundi-dev is reconciled by ArgoCD. This job bumps the image tag in
     # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-dev.yaml and
     # lets ArgoCD's automated selfHeal pick up the change.
     uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/main')
-    needs: [vars, build]
+    needs: [vars, build_serca]
     with:
       app-name: movebank-dispatcher
       environment: gundi-dev
-      image-repository: ${{ needs.vars.outputs.repository }}
+      image-repository: ${{ needs.vars.outputs.serca_repository }}
       image-tag: ${{ needs.vars.outputs.tag }}
     secrets: inherit  # pragma: allowlist secret
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/python:3.8-slim
 
 WORKDIR /app
 COPY requirements.txt .


### PR DESCRIPTION
## Summary

Add a parallel build to push the movebank-dispatcher image to `serca-artifact-registry/gundi/movebank-dispatcher` using Direct WIF, update `deploy_dev` to use the new registry, and switch the Dockerfile base image through the virtual-docker mirror.

## Changes

### Added
- `serca_repository` output to `vars` job (`europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/movebank-dispatcher`)
- `build_serca` job: builds and pushes to serca-artifact-registry via Direct WIF (no `environment:`, no `service_account:`), depends on `run_unit_tests`

### Changed
- `deploy_dev` now depends on `build_serca` and passes `serca_repository` as `image-repository` — critical because `deploy_argocd.yml@v8` updates both `image.repository` and `image.tag` via yq on every run
- `docker/Dockerfile` `FROM` now uses `virtual-docker` mirror to avoid DockerHub rate limits
- `deploy_stage`/`deploy_prod` unchanged (still use cdip-78ca during transition)

## Files Changed

**2 files changed, 14 insertions(+), 4 deletions(-)**

---
**Jira**: https://padas.atlassian.net/browse/DASOPS-2057