### PR TITLE
fix(DASOPS-2057): use serca-artifact-registry, ArgoCD deploys, approve_prod gate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - id: vars
         run: |
           echo "tag=${{ github.head_ref || github.ref_name }}-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "repository=us-central1-docker.pkg.dev/cdip-78ca/gundi/movebank-dispatcher" >> $GITHUB_OUTPUT
+          echo "repository=europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/movebank-dispatcher" >> $GITHUB_OUTPUT
 
   run_unit_tests:
       runs-on: ubuntu-latest
@@ -27,7 +27,7 @@ jobs:
           uses: actions/checkout@v4
         - uses: actions/setup-python@v5
           with:
-            python-version: '3.8' 
+            python-version: '3.8'
         - name: Install pip
           run: python -m ensurepip --upgrade
         - name: Install dependencies
@@ -37,51 +37,66 @@ jobs:
         - name: Run unit tests
           run: pytest -s
           env:
-            MOVEBANK_PASSWORD: test
-            MOVEBANK_USERNAME: test
-            TRANSFORMED_OBSERVATIONS_SUB_ID: test
+            MOVEBANK_PASSWORD: test  # pragma: allowlist secret
+            MOVEBANK_USERNAME: test  # pragma: allowlist secret
+            TRANSFORMED_OBSERVATIONS_SUB_ID: test  # pragma: allowlist secret
             TRACING_ENABLED: False
 
   build:
-    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v2
-    needs: [run_unit_tests,vars]
+    uses: PADAS/gundi-workflows/.github/workflows/build_docker.yml@v11
+    needs: [run_unit_tests, vars]
     with:
-      environment: stage
+      workload_identity_provider: "projects/563316706574/locations/global/workloadIdentityPools/github-actions/providers/github-oidc"  # pragma: allowlist secret
       repository: ${{ needs.vars.outputs.repository }}
       tag: ${{ needs.vars.outputs.tag }}
+      build-args: BASE_REGISTRY=europe-west3-docker.pkg.dev/serca-artifact-registry/virtual-docker/
 
   deploy_dev:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    # gundi-dev is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-dev.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/main')
     needs: [vars, build]
     with:
-      environment: dev
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
-    secrets: inherit
+      app-name: movebank-dispatcher
+      environment: gundi-dev
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
+    secrets: inherit  # pragma: allowlist secret
 
   deploy_stage:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+    # gundi-stage is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-stage.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build]
     with:
-      environment: stage
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
-    secrets: inherit
+      app-name: movebank-dispatcher
+      environment: gundi-stage
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
+    secrets: inherit  # pragma: allowlist secret
 
-  deploy_prod:
-    uses: PADAS/gundi-workflows/.github/workflows/deploy_k8s.yml@v2
+  approve_prod:
+    runs-on: ubuntu-latest
+    environment: prod
     if: startsWith(github.ref, 'refs/heads/release')
     needs: [vars, build, deploy_stage]
+    steps:
+      - run: echo "Approved for prod"
+
+  deploy_prod:
+    # gundi-prod is reconciled by ArgoCD. This job bumps the image tag in
+    # PADAS/serca-argocd-apps:gundi/movebank-dispatcher/values-gundi-prod.yaml and
+    # lets ArgoCD's automated selfHeal pick up the change.
+    uses: PADAS/gundi-workflows/.github/workflows/deploy_argocd.yml@v8
+    if: startsWith(github.ref, 'refs/heads/release')
+    needs: [vars, build, deploy_stage, approve_prod]
     with:
-      environment: prod
-      chart_name: movebank-dispatcher
-      chart_version: '0.1.0'
-      repository: ${{ needs.vars.outputs.repository }}
-      tag: ${{ needs.vars.outputs.tag }}
-    secrets: inherit
+      app-name: movebank-dispatcher
+      environment: gundi-prod
+      image-repository: ${{ needs.vars.outputs.repository }}
+      image-tag: ${{ needs.vars.outputs.tag }}
+    secrets: inherit  # pragma: allowlist secret


### PR DESCRIPTION
## Summary

Backport the CI/CD workflow changes from main to \`release-202508211633\` so a pending prod deploy uses serca-artifact-registry + ArgoCD (not the old Helm path), and adds the \`approve_prod\` gate to restore the approval requirement that was missing from the ArgoCD-based workflow.

## Changes

### Changed
- \`repository\` → \`europe-west3-docker.pkg.dev/serca-artifact-registry/gundi/movebank-dispatcher\`
- \`build\` → \`build_docker.yml@v11\` with Direct WIF
- \`deploy_dev\` / \`deploy_stage\` / \`deploy_prod\` → \`deploy_argocd.yml@v8\`
- Added \`approve_prod\` gate job (\`environment: prod\`) — \`deploy_prod\` requires approval before running

## Technical Details

The old \`deploy_k8s.yml@v2\` enforced approval via \`environment: prod\` internally. \`deploy_argocd.yml@v8\` does not declare a GitHub Actions environment, so the gate was absent. The \`approve_prod\` job pattern restores it: it has \`environment: prod\` (with required reviewers) and \`deploy_prod\` lists it as a dependency.

**Jira**: https://padas.atlassian.net/browse/DASOPS-2057